### PR TITLE
Add Dockerfile for ubuntu:latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 cmake-build-debug/
 .idea/
+build/

--- a/docker/ubuntu_latest/Dockerfile
+++ b/docker/ubuntu_latest/Dockerfile
@@ -1,0 +1,73 @@
+FROM ubuntu:latest
+
+LABEL author="xmei@jlab.org"
+LABEL description="Put xmsg-cpp, ersap-cpp, ersap-java and ersap-jana env together"
+
+ENV DEPS=/deps
+WORKDIR $DEPS
+
+USER root
+
+# some general software
+RUN apt update -y && \
+        apt -y install --no-install-recommends ca-certificates git build-essential cmake libzmq5-dev libprotobuf-dev protobuf-compiler && \
+        rm -rf /var/lib/apt/lists/*
+
+# install jdk-14
+ADD https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz openjdk.tar.gz
+RUN tar xvf openjdk.tar.gz && \
+    rm -rf openjdk.tar.gz && \
+    mv jdk-14 /opt/
+ENV JAVA_HOME=/opt/jdk-14
+ENV PATH=$PATH:$JAVA_HOME/bin
+
+# build and install ersap-java
+# refer to https://github.com/JeffersonLab/ersap-java/blob/main/docker/Dockerfile
+ENV ERSAP_HOME="/usr/local/ersap"
+ENV PATH="${ERSAP_HOME}/bin:${PATH}"
+RUN git clone https://github.com/JeffersonLab/ersap-java.git && \
+    cd ersap-java && \
+    ./gradlew && \
+    ./gradlew deploy
+VOLUME ["${ERSAP_HOME}/data/input", "${ERSAP_HOME}/data/output", "${ERSAP_HOME}/log"]
+
+# build and intstall xMsg
+RUN git clone https://github.com/JeffersonLab/xmsg-cpp.git && \
+    cd xmsg-cpp && \
+    mkdir install && \
+    ./configure --prefix=${ERSAP_HOME} && \
+    make && \
+    make install
+
+# build and install ersap-cpp
+RUN git clone https://github.com/JeffersonLab/ersap-cpp.git && \
+    cd ersap-cpp && \
+    mkdir install && \
+    ./configure --prefix=${ERSAP_HOME} && \
+    make && \
+    make install
+RUN rm -rf $DEPS/ersap-* $DEPS/xmsg-cpp
+
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ERSAP_HOME}/lib
+
+# build and install JANA2
+# see the below error msg, lock down to v.2.0.6 now
+# CMake Error at /deps/JANA2/install/lib/cmake/JANA/JANAConfig.cmake:31 (get_target_property):
+#  get_target_property() called with non-existent target "JANA::jana2".
+# Call Stack (most recent call first):
+#  CMakeLists.txt:42 (find_package)
+ENV JANA_HOME=$DEPS/JANA2/install
+ENV PATH=$PATH:$JANA_HOME/bin
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JANA_HOME/plugins
+RUN git clone -b v2.0.6 http://github.com/JeffersonLab/JANA2 && \
+    cd JANA2 -&& \
+    mkdir build install && \
+    cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=$JANA_HOME && \
+    make -j8 install && \
+    cd .. && rm -rf build
+
+#what is this for? copied from https://github.com/JeffersonLab/ersap-java/blob/main/docker/Dockerfile
+EXPOSE 7771-7775
+
+WORKDIR /app


### PR DESCRIPTION
## Updates
- [x] Add a Dockerfile for ubuntu:latest, which has JANA, ersap-cpp, ersap-java and xmsg-cpp env containerized.
- [x] Add /build to .gitignore

## BUILT RESULTS

### Build and install ersap-jana
Built successfully. After `make install`,
```
root@6d6a0ecc97a6:/app/build# ls $ERSAP_HOME/plugins/jana/
lib  services
```
### Run ersap-shell
Do not know whether its expected or not.
```
ersap> set servicesFile /app/services.yaml 

ersap> run local
tee: /usr/local/ersap/plugins/epsci/log/10.0.2.100_root_ersap_fe_dpe.log: No such file or directory

==========================================
               ERSAP FE/DPE               
==========================================
 Name             = 10.0.2.100%7120_java
 Session          = root_ersap
 Start time       = 2023-01-28 02:40:50
 Version          = 1.0
 Lang             = Java
 Pool size        = 8

 Proxy Host       = 10.0.2.100
 Proxy Port       = 7120
==========================================
tee: /usr/local/ersap/plugins/epsci/log/10.0.2.100_root_ersap_cpp_dpe.log: No such file or directory
=========================================
                 ERSAP DPE               
=========================================
 Name             = 10.0.2.100%7130_cpp
 Date             = 2023-01-28 02:40:52
 Version          = 4.3
 Lang             = C++

 Proxy Host       = 10.0.2.100
 Proxy Port       = 7130

 FrontEnd Host    = 10.0.2.100
 FrontEnd Port    = 7120
 FrontEnd Lang    = Java
=========================================
java.lang.IllegalStateException: config variable 'fileList' not set
        at org.jlab.epsci.ersap.std.cli.ConfigVariable.getValue(ConfigVariable.java:174)
        at org.jlab.epsci.ersap.std.cli.Config.getValue(Config.java:327)
        at org.jlab.epsci.ersap.std.cli.Config.getString(Config.java:341)
        at org.jlab.epsci.ersap.std.cli.RunCommand$RunLocal.orchestratorCmd(RunCommand.java:98)
        at org.jlab.epsci.ersap.std.cli.RunCommand$RunLocal.runOrchestrator(RunCommand.java:71)
        at org.jlab.epsci.ersap.std.cli.RunCommand$RunLocal.execute(RunCommand.java:55)
        at org.jlab.epsci.ersap.std.cli.BaseCommand.execute(BaseCommand.java:61)
        at org.jlab.epsci.ersap.std.cli.CommandRunner.execute(CommandRunner.java:55)
        at org.jlab.epsci.ersap.std.cli.ErsapShell.internalRun(ErsapShell.java:377)
        at java.base/java.lang.Thread.run(Thread.java:832)

```

### Usage
At the ersap-jana root repo:
```
docker build /docker/ubuntu_latest/

docker run -it -v ${PWD}:/app <docker_img_id_or_tag>
```